### PR TITLE
Revert to value receiver in RichErrorMarshalFunc

### DIFF
--- a/baseapp/error.go
+++ b/baseapp/error.go
@@ -26,7 +26,7 @@ import (
 
 func RichErrorMarshalFunc(err error) interface{} {
 	switch err := err.(type) {
-	case *hatpear.PanicError:
+	case hatpear.PanicError:
 		return fmt.Sprintf("%+v", err)
 	default:
 		return errfmt.Print(err)


### PR DESCRIPTION
Panics in the example handler are correctly recovered and formatted
using a value receiver, but not with a pointer receiver.

This reverts commit 0647b1b9ed3c26c08b17210926eaf6a8cfedabe3.