### PR TITLE
Add a custom Datadog emitter

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,12 +18,28 @@
   revision = "ffb42d5bb417aa8e12b3b7ff73d028b915dafa10"
 
 [[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = "NUT"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
   digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
   name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = "NUT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
+
+[[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = "NUT"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -56,12 +72,12 @@
   version = "v1.9.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:4202ae4bc475052ad99562194dac3db816ee76f018b92cf2d699071f4c6e3f7a"
-  name = "github.com/syntaqx/go-metrics-datadog"
-  packages = ["."]
+  digest = "1:42e8c2456d7ec0f31e182c20022e74324c4da2cb3bd9069ff9b131fe33466308"
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
   pruneopts = "NUT"
-  revision = "defd050220648a3021b2bccfa09d15bcdffeea27"
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
 
 [[projects]]
   digest = "1:f23222558887a5919f8e9021ecb205395de463f031dd0c049e6e8e547b57c3f4"
@@ -96,12 +112,13 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/DataDog/datadog-go/statsd",
     "github.com/bluekeyes/hatpear",
     "github.com/pkg/errors",
     "github.com/rcrowley/go-metrics",
     "github.com/rs/zerolog",
     "github.com/rs/zerolog/hlog",
-    "github.com/syntaqx/go-metrics-datadog",
+    "github.com/stretchr/testify/assert",
     "goji.io",
     "goji.io/pat",
     "gopkg.in/yaml.v2",

--- a/baseapp/datadog/datadog.go
+++ b/baseapp/datadog/datadog.go
@@ -14,13 +14,22 @@
 
 // Package datadog defines configuration and functions for emitting metrics to
 // Datadog using the DogStatd protocol.
+//
+// It supports a special format for metric names to add metric-specific tags:
+//
+//   metricName[tag1,tag2:value2,...]
+//
+// Global tags for all metrics can be set in the configuration.
 package datadog
 
 import (
+	"context"
+	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-go/statsd"
 	"github.com/pkg/errors"
-	"github.com/syntaqx/go-metrics-datadog"
+	"github.com/rcrowley/go-metrics"
 
 	"github.com/palantir/go-baseapp/baseapp"
 )
@@ -46,13 +55,93 @@ func StartEmitter(s *baseapp.Server, c Config) error {
 		c.Interval = DefaultInterval
 	}
 
-	reporter, err := datadog.NewReporter(s.Registry(), c.Address, c.Interval)
+	client, err := statsd.New(c.Address)
 	if err != nil {
-		return errors.Wrap(err, "datadog: failed to create emitter")
+		return errors.Wrap(err, "datadog: failed to create client")
 	}
+	client.Tags = append(client.Tags, c.Tags...)
 
-	reporter.Client.Tags = append(reporter.Client.Tags, c.Tags...)
-	go reporter.Flush()
+	emitter := NewEmitter(client, s.Registry())
+	go emitter.Emit(context.Background(), c.Interval)
 
 	return nil
+}
+
+type Emitter struct {
+	client   *statsd.Client
+	registry metrics.Registry
+}
+
+func NewEmitter(client *statsd.Client, registry metrics.Registry) *Emitter {
+	return &Emitter{
+		registry: registry,
+		client:   client,
+	}
+}
+
+func (e *Emitter) Emit(ctx context.Context, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			e.EmitOnce()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (e *Emitter) EmitOnce() {
+	e.registry.Each(func(name string, metric interface{}) {
+		name, tags := tagsFromName(name)
+
+		switch m := metric.(type) {
+		case metrics.Counter:
+			e.client.Count(name, m.Count(), tags, 1)
+
+		case metrics.Gauge:
+			e.client.Gauge(name, float64(m.Value()), tags, 1)
+
+		case metrics.GaugeFloat64:
+			e.client.Gauge(name, m.Value(), tags, 1)
+
+		case metrics.Histogram:
+			ms := m.Snapshot()
+			e.client.Gauge(name+".avg", ms.Mean(), tags, 1)
+			e.client.Gauge(name+".count", float64(ms.Count()), tags, 1)
+			e.client.Gauge(name+".max", float64(ms.Max()), tags, 1)
+			e.client.Gauge(name+".median", ms.Percentile(0.5), tags, 1)
+			e.client.Gauge(name+".min", float64(ms.Min()), tags, 1)
+			e.client.Gauge(name+".sum", float64(ms.Sum()), tags, 1)
+			e.client.Gauge(name+".95percentile", ms.Percentile(0.95), tags, 1)
+
+		case metrics.Meter:
+			ms := m.Snapshot()
+			e.client.Gauge(name+".avg", ms.RateMean(), tags, 1)
+			e.client.Gauge(name+".count", float64(ms.Count()), tags, 1)
+			e.client.Gauge(name+".rate1", ms.Rate1(), tags, 1)
+			e.client.Gauge(name+".rate5", ms.Rate5(), tags, 1)
+			e.client.Gauge(name+".rate15", ms.Rate15(), tags, 1)
+
+		case metrics.Timer:
+			ms := m.Snapshot()
+			e.client.Gauge(name+".avg", ms.Mean(), tags, 1)
+			e.client.Gauge(name+".count", float64(ms.Count()), tags, 1)
+			e.client.Gauge(name+".max", float64(ms.Max()), tags, 1)
+			e.client.Gauge(name+".median", ms.Percentile(0.5), tags, 1)
+			e.client.Gauge(name+".min", float64(ms.Min()), tags, 1)
+			e.client.Gauge(name+".sum", float64(ms.Sum()), tags, 1)
+			e.client.Gauge(name+".95percentile", ms.Percentile(0.95), tags, 1)
+		}
+	})
+}
+
+func tagsFromName(name string) (string, []string) {
+	start := strings.IndexRune(name, '[')
+	if start < 0 || name[len(name)-1] != ']' {
+		return name, nil
+	}
+	return name[:start], strings.Split(name[start+1:len(name)-1], ",")
 }

--- a/baseapp/datadog/datadog_test.go
+++ b/baseapp/datadog/datadog_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package datadog
 
 import (

--- a/baseapp/datadog/datadog_test.go
+++ b/baseapp/datadog/datadog_test.go
@@ -1,0 +1,33 @@
+package datadog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagsFromName(t *testing.T) {
+	t.Run("noTags", func(t *testing.T) {
+		name, tags := tagsFromName("notags")
+		assert.Equal(t, "notags", name)
+		assert.Empty(t, tags)
+	})
+
+	t.Run("singleTag", func(t *testing.T) {
+		name, tags := tagsFromName("single[tag1]")
+		assert.Equal(t, "single", name)
+		assert.Equal(t, []string{"tag1"}, tags)
+	})
+
+	t.Run("multipleTags", func(t *testing.T) {
+		name, tags := tagsFromName("multiple[tag1,tag2:value]")
+		assert.Equal(t, "multiple", name)
+		assert.Equal(t, []string{"tag1", "tag2:value"}, tags)
+	})
+
+	t.Run("invalidFormat", func(t *testing.T) {
+		name, tags := tagsFromName("invalid[tag1")
+		assert.Equal(t, "invalid[tag1", name)
+		assert.Empty(t, tags)
+	})
+}

--- a/godel/config/check-plugin.yml
+++ b/godel/config/check-plugin.yml
@@ -3,3 +3,8 @@ checks:
     filters:
     - value: should have comment or be unexported
     - value: or a comment on this block
+  errcheck:
+    config:
+      exclude:
+        - (*github.com/palantir/go-baseapp/vendor/github.com/DataDog/datadog-go/statsd.Client).Count
+        - (*github.com/palantir/go-baseapp/vendor/github.com/DataDog/datadog-go/statsd.Client).Gauge


### PR DESCRIPTION
Compared to the existing version, the new implementation supports
extracting tags from metric names and emits slightly different values
for "advanced" metric types like histograms, meters, and timers.