### PR TITLE
Use functional gauges for runtime metrics

### DIFF
--- a/baseapp/params.go
+++ b/baseapp/params.go
@@ -46,7 +46,7 @@ func DefaultParams(logger zerolog.Logger, metricsPrefix string) []Param {
 		WithMiddleware(DefaultMiddleware(logger, registry)...),
 		WithUTCNanoTime(),
 		WithErrorLogging(RichErrorMarshalFunc),
-		WithMetrics(10 * time.Second),
+		WithMetrics(),
 	}
 }
 
@@ -95,14 +95,9 @@ func WithRegistry(registry metrics.Registry) Param {
 }
 
 // WithMetrics enables server and runtime metrics collection.
-func WithMetrics(interval time.Duration) Param {
+func WithMetrics() Param {
 	return func(s *Server) error {
-		s.initMetrics = func() {
-			r := s.Registry()
-			RegisterDefaultMetrics(r)
-
-			go collectGoMetrics(r, interval)
-		}
+		s.initFns = append(s.initFns, func(s *Server) { RegisterDefaultMetrics(s.Registry()) })
 		return nil
 	}
 }


### PR DESCRIPTION
There's no reason to report these at a higher rate than consumers read
them from the registry and switching to functional gauges lets us remove
a goroutine. While making this change, refactor the server code a bit to
avoid having a metrics-specific initialization function, which always
felt weird.

Note that this is a breaking change for users that use the WithMetrics
parameter directly, as it no longer takes an interval. I think this is
acceptable as it's an easy fix and all our existing internal clients use
the default parameters.