### PR TITLE
TLS Support added

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -101,12 +101,12 @@
   version = "v2.0"
 
 [[projects]]
-  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
+  digest = "1:18108594151654e9e696b27b181b953f9a90b16bf14d253dd1b397b025a1487f"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/baseapp/config.go
+++ b/baseapp/config.go
@@ -15,8 +15,8 @@
 package baseapp
 
 type TLSConfig struct {
-	CertificateFile string `yaml:"cert_file" json:"certFile"`
-	PrivateKeyFile  string `yaml:"private_key_file" json:"privateKeyFile"`
+	CertFile string `yaml:"cert_file" json:"certFile"`
+	KeyFile  string `yaml:"key_file" json:"keyFile"`
 }
 
 // HTTPConfig contains options for HTTP servers. It is usually embedded in a

--- a/baseapp/config.go
+++ b/baseapp/config.go
@@ -14,10 +14,16 @@
 
 package baseapp
 
+type TLSConfig struct {
+	CertificateFile string `yaml:"cert_file" json:"certFile"`
+	PrivateKeyFile  string `yaml:"private_key_file" json:"privateKeyFile"`
+}
+
 // HTTPConfig contains options for HTTP servers. It is usually embedded in a
 // larger configuration struct.
 type HTTPConfig struct {
-	Address   string `yaml:"address" json:"address"`
-	Port      int    `yaml:"port" json:"port"`
-	PublicURL string `yaml:"public_url" json:"publicUrl"`
+	Address   string     `yaml:"address" json:"address"`
+	Port      int        `yaml:"port" json:"port"`
+	PublicURL string     `yaml:"public_url" json:"publicUrl"`
+	TLSConfig *TLSConfig `yaml:"tls_config" json:"tlsConfig"`
 }

--- a/baseapp/params.go
+++ b/baseapp/params.go
@@ -16,6 +16,7 @@ package baseapp
 
 import (
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/rcrowley/go-metrics"
@@ -47,6 +48,7 @@ func DefaultParams(logger zerolog.Logger, metricsPrefix string) []Param {
 		WithUTCNanoTime(),
 		WithErrorLogging(RichErrorMarshalFunc),
 		WithMetrics(),
+		WithHTTPServer(nil),
 	}
 }
 
@@ -98,6 +100,22 @@ func WithRegistry(registry metrics.Registry) Param {
 func WithMetrics() Param {
 	return func(s *Server) error {
 		s.initFns = append(s.initFns, func(s *Server) { RegisterDefaultMetrics(s.Registry()) })
+		return nil
+	}
+}
+
+func WithHTTPServer(server *http.Server) Param {
+	return func(s *Server) error {
+		if server == nil {
+			addr := s.config.Address + ":" + strconv.Itoa(s.config.Port)
+			s.server = &http.Server{
+				Addr:    addr,
+				Handler: s.mux,
+			}
+		} else {
+			s.server = server
+		}
+
 		return nil
 	}
 }

--- a/baseapp/params.go
+++ b/baseapp/params.go
@@ -16,7 +16,6 @@ package baseapp
 
 import (
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/rcrowley/go-metrics"
@@ -48,7 +47,6 @@ func DefaultParams(logger zerolog.Logger, metricsPrefix string) []Param {
 		WithUTCNanoTime(),
 		WithErrorLogging(RichErrorMarshalFunc),
 		WithMetrics(),
-		WithHTTPServer(nil),
 	}
 }
 
@@ -106,16 +104,7 @@ func WithMetrics() Param {
 
 func WithHTTPServer(server *http.Server) Param {
 	return func(s *Server) error {
-		if server == nil {
-			addr := s.config.Address + ":" + strconv.Itoa(s.config.Port)
-			s.server = &http.Server{
-				Addr:    addr,
-				Handler: s.mux,
-			}
-		} else {
-			s.server = server
-		}
-
+		s.server = server
 		return nil
 	}
 }

--- a/baseapp/server.go
+++ b/baseapp/server.go
@@ -104,9 +104,8 @@ func (s *Server) Start() error {
 	s.logger.Info().Msgf("Server listening on %s", addr)
 
 	tlsConfig := s.config.TLSConfig
-
 	if tlsConfig != nil {
-		return http.ListenAndServeTLS(addr, s.config.TLSConfig.CertificateFile, s.config.TLSConfig.PrivateKeyFile, s.mux)
+		return http.ListenAndServeTLS(addr, tlsConfig.CertificateFile, tlsConfig.PrivateKeyFile, s.mux)
 	}
 
 	return http.ListenAndServe(addr, s.mux)

--- a/baseapp/server.go
+++ b/baseapp/server.go
@@ -70,12 +70,6 @@ func NewServer(c HTTPConfig, params ...Param) (*Server, error) {
 		base.mux.Use(middleware)
 	}
 
-	addr := c.Address + ":" + strconv.Itoa(c.Port)
-	base.server = &http.Server{
-		Addr:    addr,
-		Handler: base.mux,
-	}
-
 	return base, nil
 }
 

--- a/baseapp/server.go
+++ b/baseapp/server.go
@@ -70,6 +70,19 @@ func NewServer(c HTTPConfig, params ...Param) (*Server, error) {
 		base.mux.Use(middleware)
 	}
 
+	if base.server == nil {
+		base.server = &http.Server{}
+	}
+
+	if base.server.Addr == "" {
+		addr := c.Address + ":" + strconv.Itoa(c.Port)
+		base.server.Addr = addr
+	}
+
+	if base.server.Handler == nil {
+		base.server.Handler = base.mux
+	}
+
 	return base, nil
 }
 

--- a/baseapp/server.go
+++ b/baseapp/server.go
@@ -15,7 +15,6 @@
 package baseapp
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -73,9 +72,8 @@ func NewServer(c HTTPConfig, params ...Param) (*Server, error) {
 
 	addr := c.Address + ":" + strconv.Itoa(c.Port)
 	base.server = &http.Server{
-		Addr:      addr,
-		Handler:   base.mux,
-		TLSConfig: &tls.Config{},
+		Addr:    addr,
+		Handler: base.mux,
 	}
 
 	return base, nil

--- a/baseapp/server.go
+++ b/baseapp/server.go
@@ -102,6 +102,13 @@ func (s *Server) Start() error {
 
 	addr := s.config.Address + ":" + strconv.Itoa(s.config.Port)
 	s.logger.Info().Msgf("Server listening on %s", addr)
+
+	tlsConfig := s.config.TLSConfig
+
+	if tlsConfig != nil {
+		return http.ListenAndServeTLS(addr, s.config.TLSConfig.CertificateFile, s.config.TLSConfig.PrivateKeyFile, s.mux)
+	}
+
 	return http.ListenAndServe(addr, s.mux)
 }
 

--- a/baseapp/server.go
+++ b/baseapp/server.go
@@ -105,7 +105,7 @@ func (s *Server) Start() error {
 
 	tlsConfig := s.config.TLSConfig
 	if tlsConfig != nil {
-		return http.ListenAndServeTLS(addr, tlsConfig.CertificateFile, tlsConfig.PrivateKeyFile, s.mux)
+		return http.ListenAndServeTLS(addr, tlsConfig.CertFile, tlsConfig.KeyFile, s.mux)
 	}
 
 	return http.ListenAndServe(addr, s.mux)


### PR DESCRIPTION
Allows for listening to request on TLS. If the `TLSConfig` property is not set, it is assumed that no TLS listening is required