### PR TITLE
Expose underlying HTTP server by function

### DIFF
--- a/baseapp/server.go
+++ b/baseapp/server.go
@@ -91,6 +91,11 @@ func (s *Server) HTTPConfig() HTTPConfig {
 	return s.config
 }
 
+// HTTPServer returns the underlying HTTP Server.
+func (s *Server) HTTPServer() *http.Server {
+	return s.server
+}
+
 // Mux returns the root mux for the server.
 func (s *Server) Mux() *goji.Mux {
 	return s.mux


### PR DESCRIPTION
Exposes the underlying HTTP Server. This allows for things like gracefully terminating the server