### PR TITLE
Provide sane logging configuration and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ func main() {
         Address: "127.0.0.1",
         Port:    "8000",
     }
+    loggingConfig := baseapp.LoggingConfig{
+        Pretty: true,
+        Level: "debug",
+    }
 
-	logger, err := baseapp.ConfigureDefaultLogger(config.Logging)
-	if err != nil {
-		panic(err)
-	}
+    logger := baseapp.NewLogger(loggingConfig)
 
     // create a server with default options and no metrics prefix
     server, err := baseapp.NewServer(config, baseapp.DefaultParams(logger, "")...)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ func main() {
         Port:    "8000",
     }
 
-    logger := zerolog.New(os.Stdout).With().Timestamp().Logger()
+	logger, err := baseapp.ConfigureDefaultLogger(config.Logging)
+	if err != nil {
+		panic(err)
+	}
 
     // create a server with default options and no metrics prefix
     server, err := baseapp.NewServer(config, baseapp.DefaultParams(logger, "")...)

--- a/baseapp/config.go
+++ b/baseapp/config.go
@@ -31,8 +31,8 @@ type HTTPConfig struct {
 // LoggingConfig contains options for logging, such as log level and textual representation.
 // It is usually embedded in a larger configuration struct.
 type LoggingConfig struct {
-	Level string `yaml:"level"`
+	Level string `yaml:"level" json:"level"`
 
 	// Pretty will make the output human-readable
-	Pretty bool `yaml:"pretty"`
+	Pretty bool `yaml:"pretty" json:"pretty"`
 }

--- a/baseapp/config.go
+++ b/baseapp/config.go
@@ -27,3 +27,10 @@ type HTTPConfig struct {
 	PublicURL string     `yaml:"public_url" json:"publicUrl"`
 	TLSConfig *TLSConfig `yaml:"tls_config" json:"tlsConfig"`
 }
+
+// LoggingConfig contains options for logging, such as log level and textual representation.
+// It is usually embedded in a larger configuration struct.
+type LoggingConfig struct {
+	Level string `yaml:"level"`
+	Text  bool   `yaml:"text"`
+}

--- a/baseapp/config.go
+++ b/baseapp/config.go
@@ -32,5 +32,7 @@ type HTTPConfig struct {
 // It is usually embedded in a larger configuration struct.
 type LoggingConfig struct {
 	Level string `yaml:"level"`
-	Text  bool   `yaml:"text"`
+
+	// Pretty will make the output human-readable
+	Pretty bool `yaml:"pretty"`
 }

--- a/baseapp/logging.go
+++ b/baseapp/logging.go
@@ -1,0 +1,43 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package baseapp
+
+import (
+	"io"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+// ConfigureDefaultLogger returns a zerolog logger based on the conventions in a LoggingConfig
+func ConfigureDefaultLogger(c LoggingConfig) (zerolog.Logger, error) {
+	out := io.Writer(os.Stdout)
+	if c.Text {
+		out = zerolog.ConsoleWriter{Out: out}
+	}
+
+	logger := zerolog.New(out).With().Timestamp().Logger()
+	if c.Level == "" {
+		return logger, nil
+	}
+
+	level, err := zerolog.ParseLevel(c.Level)
+	if err != nil {
+		return logger, errors.Wrap(err, "failed to parse log level")
+	}
+
+	return logger.Level(level), nil
+}

--- a/baseapp/logging.go
+++ b/baseapp/logging.go
@@ -18,26 +18,26 @@ import (
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
 
-// ConfigureDefaultLogger returns a zerolog logger based on the conventions in a LoggingConfig
-func ConfigureDefaultLogger(c LoggingConfig) (zerolog.Logger, error) {
+// NewLogger returns a zerolog logger based on the conventions in a LoggingConfig
+func NewLogger(c LoggingConfig) zerolog.Logger {
 	out := io.Writer(os.Stdout)
-	if c.Text {
+	if c.Pretty {
 		out = zerolog.ConsoleWriter{Out: out}
 	}
 
 	logger := zerolog.New(out).With().Timestamp().Logger()
 	if c.Level == "" {
-		return logger, nil
+		return logger
 	}
 
 	level, err := zerolog.ParseLevel(c.Level)
 	if err != nil {
-		return logger, errors.Wrap(err, "failed to parse log level")
+		logger.Warn().Str("level", c.Level).Msg("Failed to parse log level")
+		return logger
 	}
 
-	return logger.Level(level), nil
+	return logger.Level(level)
 }

--- a/baseapp/logging.go
+++ b/baseapp/logging.go
@@ -35,7 +35,7 @@ func NewLogger(c LoggingConfig) zerolog.Logger {
 
 	level, err := zerolog.ParseLevel(c.Level)
 	if err != nil {
-		logger.Warn().Str("level", c.Level).Msg("Failed to parse log level")
+		logger.Warn().Msgf("Invalid log level %q, using the default level instead", c.Level)
 		return logger
 	}
 

--- a/example/config.go
+++ b/example/config.go
@@ -25,8 +25,9 @@ import (
 )
 
 type Config struct {
-	Server  baseapp.HTTPConfig `yaml:"server"`
-	Datadog datadog.Config     `yaml:"datadog"`
+	Server  baseapp.HTTPConfig    `yaml:"server"`
+	Datadog datadog.Config        `yaml:"datadog"`
+	Logging baseapp.LoggingConfig `yaml:"logging"`
 
 	App AppConfig `yaml:"app"`
 }

--- a/example/config.yml
+++ b/example/config.yml
@@ -3,7 +3,7 @@ server:
     port: 8080
 
 logging:
-    text: false
+    pretty: false
     level: debug
 
 app:

--- a/example/config.yml
+++ b/example/config.yml
@@ -2,5 +2,9 @@ server:
     address: 127.0.0.1
     port: 8080
 
+logging:
+    text: false
+    level: debug
+
 app:
     message: "The bird is the word."

--- a/example/main.go
+++ b/example/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"net/http"
-	"os"
 
 	"github.com/rs/zerolog"
 	"goji.io/pat"
@@ -52,7 +51,10 @@ func main() {
 	}
 
 	// Configure a root logger for everything to use
-	logger := zerolog.New(os.Stdout).With().Timestamp().Logger()
+	logger, err := baseapp.ConfigureDefaultLogger(config.Logging)
+	if err != nil {
+		panic(err)
+	}
 
 	// Create a server using the default options
 	serverParams := baseapp.DefaultParams(logger, "example.")

--- a/example/main.go
+++ b/example/main.go
@@ -51,10 +51,7 @@ func main() {
 	}
 
 	// Configure a root logger for everything to use
-	logger, err := baseapp.ConfigureDefaultLogger(config.Logging)
-	if err != nil {
-		panic(err)
-	}
+	logger := baseapp.NewLogger(config.Logging)
 
 	// Create a server using the default options
 	serverParams := baseapp.DefaultParams(logger, "example.")


### PR DESCRIPTION
Currently we provide a very simple interface for logging:
just pass the logger to DefaultParams, and construct your own.

I think it would be friendly to provide the pattern we've started
to use more often as an optional feature.