### PR TITLE
Add SAML authentication handlers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,14 @@
   version = "2.1.0"
 
 [[projects]]
+  digest = "1:15e3271f463f2f40d98bf426aabb86941fc66b10272ccfdfebe548683e37acb1"
+  name = "github.com/beevik/etree"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "8aee6516be3b1163bb6450c35c50e4969e3a3aa8"
+  version = "v1.1.0"
+
+[[projects]]
   branch = "master"
   digest = "1:dd49560573b3eeb2993a036b2dfebf301b7ed2c9220a77322b0747f0257cebdc"
   name = "github.com/bluekeyes/hatpear"
@@ -18,12 +26,32 @@
   revision = "ffb42d5bb417aa8e12b3b7ff73d028b915dafa10"
 
 [[projects]]
+  branch = "master"
+  digest = "1:0f7aba495a03f771f2b79f58253dbce5556b03a3d9c27e538b2e6a1c9851ee28"
+  name = "github.com/crewjam/saml"
+  packages = [
+    ".",
+    "logger",
+    "xmlenc",
+  ]
+  pruneopts = "NUT"
+  revision = "344d075952c9343809f57f4e465504dd5e3068a4"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   pruneopts = "NUT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
+
+[[projects]]
+  digest = "1:6b1eae4bb93e5ccd23cb09d1e005ecb391316d27701b7a5264f8555a6e2f3d87"
+  name = "github.com/jonboulle/clockwork"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "2eee05ed794112d45db504eb05aa693efd2b8b09"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
@@ -72,6 +100,18 @@
   version = "v1.9.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:61ceb5558efc2cddc251dbec312749caf8a0a8e3f8aca237e138f9260aa4a958"
+  name = "github.com/russellhaering/goxmldsig"
+  packages = [
+    ".",
+    "etreeutils",
+    "types",
+  ]
+  pruneopts = "NUT"
+  revision = "7acd5e4a6ef74fe1b082c20f119556adf70c3944"
+
+[[projects]]
   digest = "1:42e8c2456d7ec0f31e182c20022e74324c4da2cb3bd9069ff9b131fe33466308"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
@@ -101,6 +141,14 @@
   version = "v2.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:1fa95129371749532e2ac8b93a0016c549ebe77f25c6fad296b6ee271fae2fd6"
+  name = "golang.org/x/crypto"
+  packages = ["ripemd160"]
+  pruneopts = "NUT"
+  revision = "34f69633bfdcf9db92f698f8487115767eebef81"
+
+[[projects]]
   digest = "1:18108594151654e9e696b27b181b953f9a90b16bf14d253dd1b397b025a1487f"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -114,6 +162,7 @@
   input-imports = [
     "github.com/DataDog/datadog-go/statsd",
     "github.com/bluekeyes/hatpear",
+    "github.com/crewjam/saml",
     "github.com/pkg/errors",
     "github.com/rcrowley/go-metrics",
     "github.com/rs/zerolog",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -2,3 +2,8 @@
   go-tests = true
   non-go = true
   unused-packages = true
+
+
+[[constraint]]
+  name = "github.com/crewjam/saml"
+  branch = "master"

--- a/baseapp/auth/saml/README.md
+++ b/baseapp/auth/saml/README.md
@@ -1,0 +1,46 @@
+This package provides basic integration for baseapp with a SAML IDP.  The package handles the auth flow with the IDP (ACS and redirect).  It does not implement any session tracking/memory so users must implement their own.
+
+There are 3 main integration points users should be aware of:
+
+1. `ErrorCallback`: called whenever an error occurs during the auth flow.  The callback is expected to send a response to the request
+2. `LoginCallback`: called when a user successfully authenticates.  The callback should create a session based on the passed in assertion.
+3. `IDStore`: used to store SAML requestID's to prevent assertion spoofing.
+
+## Example
+A simple example of how to integrate the saml package into baseapp
+
+```golang
+logger := baseapp.NewLogger(baseapp.LoggingConfig{
+    Level:  "debug",
+    Pretty: true,
+})
+
+p := baseapp.DefaultParams(logger, "")
+s, err := baseapp.NewServer(baseapp.HTTPConfig{
+    Address: "127.0.0.1",
+    Port:    8000,
+}, p...)
+
+if err != nil {
+    panic(err)
+}
+
+spParam := []saml.Param{
+    saml.WithCertificateFromFile("./cert.pem"),
+    saml.WithKeyFromFile("./key"),
+    saml.WithEntityFromURL("http://localhost:8080/simplesaml/saml2/idp/metadata.php"),
+    saml.WithACSPath("/saml/acs"),
+    saml.WithMetadataPath("/saml/metadata"),
+}
+
+sp, err := saml.NewServiceProvider(spParam...)
+if err != nil {
+    panic(err)
+}
+
+s.Mux().Handle(pat.Post("/saml/acs"), sp.ACSHandler())
+s.Mux().Handle(pat.Get("/saml/metadata"), sp.MetadataHandler())
+s.Mux().HandleFunc(pat.Get("/auth"), sp.DoAuth)
+
+_ = s.Start()
+```

--- a/baseapp/auth/saml/doc.go
+++ b/baseapp/auth/saml/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package saml provides the necessary handlers to implement a SAML authentication workflow.
+// It relies on the IDP's metadata file being accessible via HTTP.
+package saml

--- a/baseapp/auth/saml/params.go
+++ b/baseapp/auth/saml/params.go
@@ -1,0 +1,171 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package saml
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"encoding/xml"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/crewjam/saml"
+	"github.com/pkg/errors"
+)
+
+func WithCertificateFromFile(path string) Param {
+
+	return func(sp *ServiceProvider) error {
+		certBytes, err := ioutil.ReadFile(path)
+		if err != nil {
+			return errors.Wrap(err, "could not read provided certificate file")
+		}
+
+		return WithCertificateFromBytes(certBytes)(sp)
+	}
+
+}
+
+func WithCertificateFromBytes(certBytes []byte) Param {
+	return func(sp *ServiceProvider) error {
+		certPem, _ := pem.Decode(certBytes)
+		if certPem == nil {
+			return errors.New("could not PEM decode the provided certificate")
+		}
+
+		cert, err := x509.ParseCertificate(certPem.Bytes)
+		sp.sp.Certificate = cert
+		return errors.Wrap(err, "failed to parse provided certificate")
+	}
+
+}
+
+func WithKeyFromFile(path string) Param {
+	return func(sp *ServiceProvider) error {
+		keyBytes, err := ioutil.ReadFile(path)
+		if err != nil {
+			return errors.Wrap(err, "could not read provided key file")
+		}
+
+		return WithKeyFromBytes(keyBytes)(sp)
+	}
+
+}
+
+func WithKeyFromBytes(keyBytes []byte) Param {
+
+	return func(sp *ServiceProvider) error {
+		keyPem, _ := pem.Decode(keyBytes)
+		if keyPem == nil {
+			return errors.New("could not PEM decode the provided private key")
+		}
+
+		key, err := x509.ParsePKCS8PrivateKey(keyPem.Bytes)
+		if err != nil {
+			return errors.Wrap(err, "could not parse provided private key")
+		}
+
+		rsaKey, ok := key.(*rsa.PrivateKey)
+		sp.sp.Key = rsaKey
+		if !ok {
+			return errors.New("provided private key was not an RSA key")
+		}
+		return nil
+	}
+
+}
+
+func WithEntityFromURL(url string) Param {
+
+	return func(sp *ServiceProvider) error {
+		resp, err := http.Get(url)
+		if err != nil {
+			return errors.Wrap(err, "failed to download IDP metadata")
+		}
+
+		defer func() { _ = resp.Body.Close() }()
+		descriptor, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrap(err, "failed to download IDP metadata")
+		}
+
+		return WithEntityFromBytes(descriptor)(sp)
+	}
+
+}
+
+func WithEntityFromBytes(metadata []byte) Param {
+
+	return func(sp *ServiceProvider) error {
+		var entity saml.EntityDescriptor
+
+		if err := xml.Unmarshal(metadata, &entity); err != nil {
+			return errors.Wrap(err, "could not parse returned metadata")
+		}
+		sp.sp.IDPMetadata = &entity
+		return nil
+	}
+
+}
+
+func WithACSPath(path string) Param {
+	return func(sp *ServiceProvider) error {
+		sp.acsPath = path
+		return nil
+	}
+}
+
+func WithMetadataPath(path string) Param {
+	return func(sp *ServiceProvider) error {
+		sp.metadataPath = path
+		return nil
+	}
+}
+
+func WithForceTLS(force bool) Param {
+	return func(sp *ServiceProvider) error {
+		sp.forceTLS = force
+		return nil
+	}
+}
+
+func WithLoginCallback(lcb LoginCallback) Param {
+	return func(sp *ServiceProvider) error {
+		sp.onLogin = lcb
+		return nil
+	}
+}
+
+func WithErrorCallback(ecb ErrorCallback) Param {
+	return func(sp *ServiceProvider) error {
+		sp.onError = ecb
+		return nil
+	}
+}
+
+func WithIDStore(store IDStore) Param {
+	return func(sp *ServiceProvider) error {
+		sp.idStore = store
+		return nil
+	}
+}
+
+func WithServiceProvider(s *saml.ServiceProvider) Param {
+	return func(sp *ServiceProvider) error {
+		sp.sp = s
+		return nil
+	}
+}

--- a/baseapp/auth/saml/serviceprovider.go
+++ b/baseapp/auth/saml/serviceprovider.go
@@ -1,0 +1,205 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package saml
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/url"
+
+	"github.com/crewjam/saml"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/hlog"
+)
+
+type Error struct {
+	Err error
+
+	// The suggested HTTP response code for this error
+	ResponseCode int
+}
+
+func (s Error) Error() string {
+	return s.Err.Error()
+}
+
+func newError(err error, status int) Error {
+	return Error{
+		Err:          err,
+		ResponseCode: status,
+	}
+}
+
+// ErrorCallback is called whenever an error occurs in the saml package.
+// The callback is expected to send a response to the request. The http.ResponseWriter
+// will not have been written to, allowing the callback to send headers if desired.
+type ErrorCallback func(http.ResponseWriter, *http.Request, Error)
+
+// LoginCallback is called whenever an auth flow is successfully completed.
+// The callback is responsible preserving the login state.
+type LoginCallback func(http.ResponseWriter, *http.Request, *saml.Assertion)
+
+// ServiceProvider is capable of handling a SAML login. It provides
+// an http.Handler (via ACSHandler) which can process the http POST from the SAML IDP. It accepts callbacks for both error and
+// success conditions so that clients can take action after the auth flow is complete. It also provides a handler
+// for serving the service provider metadata XML.
+type ServiceProvider struct {
+	sp           *saml.ServiceProvider
+	acsPath      string
+	metadataPath string
+	forceTLS     bool
+	onError      ErrorCallback
+	onLogin      LoginCallback
+	idStore      IDStore
+}
+
+type Param func(sp *ServiceProvider) error
+
+// NewServiceProvider returns a ServiceProvider. The configuration of the ServiceProvider
+// is a result of combinging settings provided to this method and values parsed from the IDP's metadata.
+func NewServiceProvider(params ...Param) (*ServiceProvider, error) {
+
+	sp := &ServiceProvider{
+		sp: &saml.ServiceProvider{},
+	}
+
+	for _, p := range params {
+		if err := p(sp); err != nil {
+			return nil, err
+		}
+	}
+
+	if sp.sp.Certificate == nil || sp.sp.Key == nil {
+		return nil, errors.New("a certificate and key must be provided")
+	}
+
+	if sp.sp.IDPMetadata == nil {
+		return nil, errors.New("the IDP Metadata must be provided")
+	}
+
+	if sp.acsPath == "" || sp.metadataPath == "" {
+		return nil, errors.New("ACS Path and Metadatda path must be provided")
+	}
+
+	if sp.onError == nil {
+		sp.onError = DefaultErrorCallback
+	}
+
+	if sp.onLogin == nil {
+		sp.onLogin = DefaultLoginCallback
+	}
+
+	if sp.idStore == nil {
+		sp.idStore = cookieIDStore{}
+	}
+
+	return sp, nil
+}
+
+func DefaultErrorCallback(w http.ResponseWriter, r *http.Request, err Error) {
+	hlog.FromRequest(r).Error().Err(err.Err).Msg("saml error")
+	http.Error(w, http.StatusText(err.ResponseCode), err.ResponseCode)
+}
+
+func DefaultLoginCallback(w http.ResponseWriter, r *http.Request, resp *saml.Assertion) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *ServiceProvider) getSAMLSettingsForRequest(r *http.Request) *saml.ServiceProvider {
+
+	//make a copy in case different requests have different host headers
+	newSP := *s.sp
+
+	u := url.URL{
+		Host:   r.Host,
+		Scheme: "http",
+	}
+
+	if s.forceTLS || r.TLS != nil {
+		u.Scheme = "https"
+	}
+
+	u.Path = s.metadataPath
+	newSP.MetadataURL = u
+	u.Path = s.acsPath
+	newSP.AcsURL = u
+
+	return &newSP
+}
+
+// DoAuth takes an http.ResponseWriter that has not been written to yet, and conducts and SP initiated login
+// If the flow proceeds correctly the user should be redirected to the handler provided by ACSHandler().
+func (s *ServiceProvider) DoAuth(w http.ResponseWriter, r *http.Request) {
+	sp := s.getSAMLSettingsForRequest(r)
+
+	request, err := sp.MakeAuthenticationRequest(sp.GetSSOBindingLocation(saml.HTTPRedirectBinding))
+	if err != nil {
+		s.onError(w, r, newError(errors.Wrap(err, "failed to create authentication request"), http.StatusInternalServerError))
+		return
+	}
+
+	if err := s.idStore.StoreID(w, r, request.ID); err != nil {
+		s.onError(w, r, newError(errors.Wrap(err, "failed to store SAML request id"), http.StatusInternalServerError))
+		return
+	}
+
+	target := request.Redirect("")
+
+	http.Redirect(w, r, target.String(), http.StatusFound)
+}
+
+// ACSHandler returns an http.Handler which is capable of validating and processing SAML Responses.
+func (s *ServiceProvider) ACSHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sp := s.getSAMLSettingsForRequest(r)
+		if err := r.ParseForm(); err != nil {
+			s.onError(w, r, newError(errors.Wrap(err, "could not parse ACS form"), http.StatusForbidden))
+			return
+		}
+		id, err := s.idStore.GetID(r)
+		if err != nil {
+			s.onError(w, r, newError(errors.Wrap(err, "could not retrieve id"), http.StatusForbidden))
+			return
+		}
+		assertion, err := sp.ParseResponse(r, []string{id})
+
+		if err != nil {
+			if parseErr, ok := err.(*saml.InvalidResponseError); ok {
+				err = parseErr.PrivateErr
+			}
+			s.onError(w, r, newError(errors.Wrap(err, "failed to validate SAML assertion"), http.StatusForbidden))
+			return
+		}
+
+		s.onLogin(w, r, assertion)
+	})
+
+}
+
+// MetadataHandler returns an http.Handler which sends the generated metadata XML in response to a request
+func (s *ServiceProvider) MetadataHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		md, err := xml.Marshal(s.getSAMLSettingsForRequest(r).Metadata())
+		if err != nil {
+			s.onError(w, r, newError(errors.Wrap(err, "failed to generate service provider metadata"), http.StatusInternalServerError))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/xml")
+		// The error isn't handlable or recoverable so don't handle it
+		// assign to _ to placate errcheck
+		_, _ = w.Write(md)
+	})
+}

--- a/baseapp/auth/saml/state.go
+++ b/baseapp/auth/saml/state.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package saml
+
+import (
+	"net/http"
+	"time"
+)
+
+// IDStore stores the request id for SAML auth flows
+type IDStore interface {
+	// StoreID stores a request ID in such a way that it can be
+	// retreived later using GetIDs
+	StoreID(w http.ResponseWriter, r *http.Request, id string) error
+
+	// GetIDs returns the currently valid request ID for SAML authentication
+	// If no ID is found an empty string should be returned without an error
+	GetID(r *http.Request) (string, error)
+}
+
+// cookieIDStore is the default insecure id store useful for testing and development.
+// for producion use cases a secure tamper proof implementation of IDStore is strongly recommended.
+type cookieIDStore struct{}
+
+func (c cookieIDStore) StoreID(w http.ResponseWriter, _ *http.Request, id string) error {
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     "saml_id",
+		Value:    id,
+		MaxAge:   int(5 * time.Minute.Seconds()),
+		HttpOnly: true,
+		Path:     "/",
+	})
+
+	return nil
+}
+
+func (c cookieIDStore) GetID(r *http.Request) (string, error) {
+	cookie, err := r.Cookie("saml_id")
+	if err != nil {
+		if err == http.ErrNoCookie {
+			return "", nil
+		}
+
+		return "", err
+	}
+
+	return cookie.Value, nil
+}


### PR DESCRIPTION
Enables users to quickly and easily implement the SAML auth exchange in
applications based on baseapp