### PR TITLE
Add configuration for SAML logout URLs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,7 +27,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0f7aba495a03f771f2b79f58253dbce5556b03a3d9c27e538b2e6a1c9851ee28"
+  digest = "1:abea1823efa81fdf35fe4002763ed046c433c50d19afcaad403965ec50921b8e"
   name = "github.com/crewjam/saml"
   packages = [
     ".",
@@ -35,7 +35,7 @@
     "xmlenc",
   ]
   pruneopts = "NUT"
-  revision = "344d075952c9343809f57f4e465504dd5e3068a4"
+  revision = "861266e3a689a963b9a9285bb2152d201db92ef5"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"

--- a/baseapp/auth/saml/params.go
+++ b/baseapp/auth/saml/params.go
@@ -132,6 +132,9 @@ func WithEntityFromBytes(metadata []byte) Param {
 
 }
 
+// WithACSPath sets the path where the assertion consumer handler for the
+// service provider is registered. The path is included in generated metadata.
+// This is a required parameter.
 func WithACSPath(path string) Param {
 	return func(sp *ServiceProvider) error {
 		sp.acsPath = path
@@ -139,9 +142,21 @@ func WithACSPath(path string) Param {
 	}
 }
 
+// WithMetadataPath sets the path where the metadata handler for the service
+// provider is registered. The path is included in generated metadata. This is
+// a required parameter.
 func WithMetadataPath(path string) Param {
 	return func(sp *ServiceProvider) error {
 		sp.metadataPath = path
+		return nil
+	}
+}
+
+// WithLogoutPath sets the path where the single logout handler for the service
+// provider is registered. The path is included in generated metadata.
+func WithLogoutPath(path string) Param {
+	return func(sp *ServiceProvider) error {
+		sp.logoutPath = path
 		return nil
 	}
 }


### PR DESCRIPTION
While many application will not use this feature, certain IdPs (like ADFS) will not accept metadata that contains an empty string for this parameter. When not set, the corresponding element is removed from the generated metadata.