### PR TITLE
Add option to disable encrypted SAML assertions

### DIFF
--- a/baseapp/auth/saml/params.go
+++ b/baseapp/auth/saml/params.go
@@ -202,3 +202,13 @@ func WithNameIDFormat(n saml.NameIDFormat) Param {
 		return nil
 	}
 }
+
+// WithEncryptedAssertions enables or disables assertion encryption. By
+// default, encryption is enabled. When set to false, the encryption key is not
+// included in generated metadata.
+func WithEncryptedAssertions(encrypt bool) Param {
+	return func(sp *ServiceProvider) error {
+		sp.disableEncryption = !encrypt
+		return nil
+	}
+}


### PR DESCRIPTION
While you can override this in most IdPs, by default, the inclusion of
an encryption certificate in metadata suggests that the application
requires encrypted assertions. This is a reasonable default, so we
retain that, but add an option to disable this for debugging and in
situations where the claim data is not sensitive.