### PR TITLE
Improve the default HandleError middleware

### DIFF
--- a/baseapp/error.go
+++ b/baseapp/error.go
@@ -60,16 +60,14 @@ func HandleRouteError(w http.ResponseWriter, r *http.Request, err error) {
 		log = hlog.FromRequest(r).Error().Err(err)
 
 		cause := errors.Cause(err)
-		var errorMsg string
+		statusCode := http.StatusInternalServerError
 		if aerr, ok := cause.(httpError); ok {
-			errorMsg = http.StatusText(aerr.StatusCode())
-		} else {
-			errorMsg = http.StatusText(http.StatusInternalServerError)
+			statusCode = aerr.StatusCode()
 		}
 
 		rid, _ := hlog.IDFromRequest(r)
-		WriteJSON(w, http.StatusInternalServerError, map[string]string{
-			"error":      errorMsg,
+		WriteJSON(w, statusCode, map[string]string{
+			"error":      http.StatusText(statusCode),
 			"request_id": rid.String(),
 		})
 	}


### PR DESCRIPTION
Internally we have places where we have added extra information to the error handle to make debugging easier. This PR brings in some more of those modifications so that we can use standardised middleware, where possible. 

This introduces an interface to sniff out HTTP errors as well as adding a `request_id` to all errors that aren't bubbled up HTTP errors