### PR TITLE
[Proposal] Replace Goji with Gorilla Mux

### DIFF
--- a/baseapp/server.go
+++ b/baseapp/server.go
@@ -25,10 +25,10 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/rcrowley/go-metrics"
 	"github.com/rs/zerolog"
-	"goji.io"
 )
 
 // Server is the base server type. It is usually embedded in an
@@ -37,7 +37,7 @@ type Server struct {
 	config     HTTPConfig
 	middleware []func(http.Handler) http.Handler
 	logger     zerolog.Logger
-	mux        *goji.Mux
+	mux        *mux.Router
 	server     *http.Server
 
 	registry metrics.Registry
@@ -57,7 +57,7 @@ func NewServer(c HTTPConfig, params ...Param) (*Server, error) {
 		config:     c,
 		middleware: nil,
 		logger:     logger,
-		mux:        goji.NewMux(),
+		mux:        mux.NewRouter(),
 		registry:   metrics.DefaultRegistry,
 	}
 
@@ -102,7 +102,7 @@ func (s *Server) HTTPServer() *http.Server {
 }
 
 // Mux returns the root mux for the server.
-func (s *Server) Mux() *goji.Mux {
+func (s *Server) Mux() *mux.Router {
 	return s.mux
 }
 

--- a/example/main.go
+++ b/example/main.go
@@ -20,7 +20,6 @@ import (
 	"github.com/palantir/go-baseapp/baseapp"
 	"github.com/palantir/go-baseapp/baseapp/datadog"
 	"github.com/rs/zerolog"
-	"goji.io/pat"
 )
 
 type MessageHandler struct {
@@ -61,7 +60,7 @@ func main() {
 
 	// Register your routes with the server
 	messageHandler := &MessageHandler{Message: config.App.Message}
-	server.Mux().Handle(pat.Get("/api/message"), messageHandler)
+	server.Mux().Handle("/api/message", messageHandler).Methods("GET")
 
 	// Start a goroutine to emit server metrics to Datadog
 	if err := datadog.StartEmitter(server, config.Datadog); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,13 @@ require (
 	github.com/DataDog/datadog-go v0.0.0-20180330214955-e67964b4021a
 	github.com/bluekeyes/hatpear v0.1.1
 	github.com/crewjam/saml v0.4.5
+	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/sessions v1.2.1
 	github.com/pkg/errors v0.8.1
 	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/rs/zerolog v1.9.1
 	github.com/stretchr/testify v1.6.1
-	goji.io v2.0.0+incompatible
 	golang.org/x/oauth2 v0.0.0-20210113205817-d3ed898aa8a3
 	gopkg.in/yaml.v2 v2.2.4
 )

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
@@ -157,8 +159,6 @@ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
-goji.io v2.0.0+incompatible h1:QY6NuzeDeRk+8Iby4IfuN/k0d82K+fDFslQF2I2f6AM=
-goji.io v2.0.0+incompatible/go.mod h1:sbqFwrtqZACxLBTQcdgVjFh54yGVCvwq8+w49MVMMIk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
Goji appears to no longer be under active development with the last commit in September 2019, when it removed its failed attempt to convert it to a proper go module. `gorilla/mux` appears to do everything that `goji` does, plus it has an OpenTelemetry plugin and allows for query string matching.