### PR TITLE
add cipher list from mozilla recommended

### DIFF
--- a/baseapp/server.go
+++ b/baseapp/server.go
@@ -85,11 +85,9 @@ func NewServer(c HTTPConfig, params ...Param) (*Server, error) {
 					// http/2 support
 					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 
-					// intermediate/recommended compatibility for server-side TLS
+					// The set of cipher suites from Mozilla's Recommended list
 					// https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
-					tls.TLS_AES_128_GCM_SHA256,
-					tls.TLS_AES_256_GCM_SHA384,
-					tls.TLS_CHACHA20_POLY1305_SHA256,
+					// with 3DES algorithms removed to avoid sweet32 and https://github.com/golang/go/issues/21144
 					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,

--- a/baseapp/server.go
+++ b/baseapp/server.go
@@ -81,9 +81,6 @@ func NewServer(c HTTPConfig, params ...Param) (*Server, error) {
 			TLSConfig: &tls.Config{
 				MinVersion: tls.VersionTLS12,
 				CipherSuites: []uint16{
-					// http/2 support
-					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-
 					// The set of cipher suites from Mozilla's Recommended list
 					// https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
 					// with 3DES algorithms removed to avoid sweet32 and https://github.com/golang/go/issues/21144
@@ -91,6 +88,7 @@ func NewServer(c HTTPConfig, params ...Param) (*Server, error) {
 					tls.TLS_AES_256_GCM_SHA384,
 					tls.TLS_CHACHA20_POLY1305_SHA256,
 					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, // http2 support
 					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,

--- a/baseapp/server.go
+++ b/baseapp/server.go
@@ -80,6 +80,22 @@ func NewServer(c HTTPConfig, params ...Param) (*Server, error) {
 		base.server = &http.Server{
 			TLSConfig: &tls.Config{
 				MinVersion: tls.VersionTLS12,
+				CipherSuites: []uint16{
+					// http/2 support
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+
+					// intermediate/recommended compatibility for server-side TLS
+					// https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+					tls.TLS_AES_128_GCM_SHA256,
+					tls.TLS_AES_256_GCM_SHA384,
+					tls.TLS_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+				},
 			},
 		}
 	}

--- a/baseapp/server.go
+++ b/baseapp/server.go
@@ -79,8 +79,7 @@ func NewServer(c HTTPConfig, params ...Param) (*Server, error) {
 	if base.server == nil {
 		base.server = &http.Server{
 			TLSConfig: &tls.Config{
-				MinVersion:               tls.VersionTLS12,
-				PreferServerCipherSuites: true,
+				MinVersion: tls.VersionTLS12,
 				CipherSuites: []uint16{
 					// http/2 support
 					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
@@ -88,8 +87,10 @@ func NewServer(c HTTPConfig, params ...Param) (*Server, error) {
 					// The set of cipher suites from Mozilla's Recommended list
 					// https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
 					// with 3DES algorithms removed to avoid sweet32 and https://github.com/golang/go/issues/21144
+					tls.TLS_AES_128_GCM_SHA256,
+					tls.TLS_AES_256_GCM_SHA384,
+					tls.TLS_CHACHA20_POLY1305_SHA256,
 					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,

--- a/baseapp/server.go
+++ b/baseapp/server.go
@@ -79,7 +79,8 @@ func NewServer(c HTTPConfig, params ...Param) (*Server, error) {
 	if base.server == nil {
 		base.server = &http.Server{
 			TLSConfig: &tls.Config{
-				MinVersion: tls.VersionTLS12,
+				MinVersion:               tls.VersionTLS12,
+				PreferServerCipherSuites: true,
 				CipherSuites: []uint16{
 					// http/2 support
 					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,

--- a/example/main.go
+++ b/example/main.go
@@ -69,5 +69,7 @@ func main() {
 	}
 
 	// Start the server (blocking)
-	_ = server.Start()
+	if err = server.Start(); err != nil {
+		logger.Error().Err(err).Msg("server failed")
+	}
 }


### PR DESCRIPTION
Adds a default list of cipher suites based on the mozilla-recommended suites:

https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29

Also adds the http2 required cipher suite