### PR TITLE
Provide Optional Param for SAML Auth

### DIFF
--- a/baseapp/auth/saml/params.go
+++ b/baseapp/auth/saml/params.go
@@ -219,3 +219,12 @@ func WithForceAuthn(force bool) Param {
 		return nil
 	}
 }
+
+// WithEntityID is optional. When set it will define the EntityID within the EntityDescriptor.
+// If left unset it will default to your metadata url.
+func WithEntityID(value string) Param {
+	return func(sp *ServiceProvider) error {
+		sp.sp.EntityID = value
+		return nil
+	}
+}


### PR DESCRIPTION
This PR provides a way to set the EntityID. This can be very handy when you have multiple applications being developed against a single IDP. IDPs I've worked with always required the EntityID to be unique as a way to identify which relying party/Enterprise app should be used when performing authentication. 