### PR TITLE
Add the appmetrics package

### DIFF
--- a/appmetrics/appmetrics.go
+++ b/appmetrics/appmetrics.go
@@ -1,0 +1,230 @@
+package appmetrics
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/rcrowley/go-metrics"
+)
+
+const (
+	MetricTag       = "metric"
+	MetricFuncTag   = "metric-func"
+	MetricSampleTag = "metric-sample"
+)
+
+const (
+	DefaultReservoirSize = 1028
+	DefaultExpDecayAlpha = 0.015
+)
+
+var (
+	counterType      = reflect.TypeOf((*metrics.Counter)(nil)).Elem()
+	gaugeType        = reflect.TypeOf((*metrics.Gauge)(nil)).Elem()
+	gaugeFloat64Type = reflect.TypeOf((*metrics.GaugeFloat64)(nil)).Elem()
+	histogramType    = reflect.TypeOf((*metrics.Histogram)(nil)).Elem()
+	meterType        = reflect.TypeOf((*metrics.Meter)(nil)).Elem()
+	timerType        = reflect.TypeOf((*metrics.Timer)(nil)).Elem()
+)
+
+func New[M any]() *M {
+	var m M
+
+	typ := reflect.TypeOf(m)
+	if typ.Kind() != reflect.Struct {
+		panic("appmetrics.New: type is not a struct")
+	}
+
+	fields, err := getMetricFields(typ)
+	if err != nil {
+		panic("appmetrics.New: " + err.Error())
+	}
+
+	v := reflect.ValueOf(&m).Elem()
+	for _, f := range fields {
+		if err := createField(v, f, f.Tag.Get(MetricTag)); err != nil {
+			panic(fmt.Sprintf("appmetrics.New: field %s: %v", f.Name, err))
+		}
+	}
+	return &m
+}
+
+func Register[M any](r metrics.Registry, m *M) error {
+	v := reflect.ValueOf(m).Elem()
+	if v.Type().Kind() != reflect.Struct {
+		panic("appmetrics.Register: type is not a struct pointer")
+	}
+
+	fields, err := getMetricFields(v.Type())
+	if err != nil {
+		panic("appmetrics.Register: " + err.Error())
+	}
+
+	for _, f := range fields {
+		name := f.Tag.Get(MetricTag)
+		if err := r.Register(name, v.FieldByIndex(f.Index).Interface()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func Unregister[M any](r metrics.Registry, m *M) {
+	v := reflect.ValueOf(m).Elem()
+	if v.Type().Kind() != reflect.Struct {
+		panic("appmetrics.Unregister: type is not a struct pointer")
+	}
+
+	fields, err := getMetricFields(v.Type())
+	if err != nil {
+		panic("appmetrics.Unregister: " + err.Error())
+	}
+
+	for _, f := range fields {
+		r.Unregister(f.Tag.Get(MetricTag))
+	}
+}
+
+func getMetricFields(typ reflect.Type) ([]reflect.StructField, error) {
+	var fields []reflect.StructField
+	for _, f := range reflect.VisibleFields(typ) {
+		if metric := f.Tag.Get(MetricTag); metric != "" {
+			if isMetricType(f.Type) {
+				fields = append(fields, f)
+			} else {
+				return nil, fmt.Errorf("field %s: metric tag appears on non-metric type %s", f.Name, f.Type)
+			}
+		}
+	}
+	return fields, nil
+}
+
+func isMetricType(typ reflect.Type) bool {
+	switch typ {
+	case counterType, gaugeType, gaugeFloat64Type, histogramType, meterType, timerType:
+		return true
+	}
+	return false
+}
+
+func createField(v reflect.Value, f reflect.StructField, metric string) error {
+	var value any
+	switch f.Type {
+	case counterType:
+		value = metrics.NewCounter()
+
+	case gaugeType:
+		if name := f.Tag.Get(MetricFuncTag); name != "" {
+			fn, err := getFunctionalGaugeMethod[int64](v, name)
+			if err != nil {
+				return err
+			}
+			value = metrics.NewFunctionalGauge(fn)
+		} else {
+			value = metrics.NewGauge()
+		}
+
+	case gaugeFloat64Type:
+		if name := f.Tag.Get(MetricFuncTag); name != "" {
+			fn, err := getFunctionalGaugeMethod[float64](v, name)
+			if err != nil {
+				return err
+			}
+			value = metrics.NewFunctionalGaugeFloat64(fn)
+		} else {
+			value = metrics.NewGaugeFloat64()
+		}
+
+	case histogramType:
+		if sample := f.Tag.Get(MetricSampleTag); sample != "" {
+			s, err := parseSample(sample)
+			if err != nil {
+				return err
+			}
+			value = metrics.NewHistogram(s)
+		} else {
+			value = metrics.NewHistogram(metrics.NewExpDecaySample(DefaultReservoirSize, DefaultExpDecayAlpha))
+		}
+
+	case meterType:
+		value = metrics.NewMeter()
+
+	case timerType:
+		if sample := f.Tag.Get(MetricSampleTag); sample != "" {
+			s, err := parseSample(sample)
+			if err != nil {
+				return err
+			}
+			value = metrics.NewCustomTimer(metrics.NewHistogram(s), metrics.NewMeter())
+		} else {
+			value = metrics.NewTimer()
+		}
+	}
+
+	v.FieldByIndex(f.Index).Set(reflect.ValueOf(value))
+	return nil
+}
+
+func getFunctionalGaugeMethod[N int64 | float64, F func() N](v reflect.Value, name string) (F, error) {
+	m := v.Addr().MethodByName(name)
+	if m.IsZero() {
+		return nil, fmt.Errorf("method does not exist: %s", name)
+	}
+	if m.Type().NumIn() != 0 {
+		return nil, fmt.Errorf("%s: method must take no parameters", name)
+	}
+	if m.Type().NumOut() != 1 {
+		return nil, fmt.Errorf("%s: method must return a single value", name)
+	}
+	if m.Type().Out(0) != reflect.TypeOf(N(0)) {
+		return nil, fmt.Errorf("%s: method must return a value of type %T", name, N(0))
+	}
+	return m.Interface().(F), nil
+}
+
+func parseSample(s string) (metrics.Sample, error) {
+	parts := strings.Split(strings.ToLower(s), ",")
+	switch parts[0] {
+	case "uniform":
+		return parseUniformSample(parts)
+	case "expdecay":
+		return parseExpDecaySample(parts)
+	default:
+		return nil, fmt.Errorf("invalid sample type")
+	}
+	return metrics.NilSample{}, nil
+}
+
+func parseUniformSample(parts []string) (metrics.Sample, error) {
+	switch len(parts) {
+	case 1:
+		return metrics.NewUniformSample(DefaultReservoirSize), nil
+	case 2:
+		rs, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return nil, fmt.Errorf("invalid uniform sample: reservoir: %w", err)
+		}
+		return metrics.NewUniformSample(rs), nil
+	}
+	return nil, fmt.Errorf("invalid uniform sample")
+}
+
+func parseExpDecaySample(parts []string) (metrics.Sample, error) {
+	switch len(parts) {
+	case 1:
+		return metrics.NewExpDecaySample(DefaultReservoirSize, DefaultExpDecayAlpha), nil
+	case 3:
+		rs, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return nil, fmt.Errorf("invalid expdecay sample: reservoir: %w", err)
+		}
+		alpha, err := strconv.ParseFloat(parts[2], 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid expdecay sample: alpha: %w", err)
+		}
+		return metrics.NewExpDecaySample(rs, alpha), nil
+	}
+	return nil, fmt.Errorf("invalid expdecay sample")
+}

--- a/appmetrics/appmetrics.go
+++ b/appmetrics/appmetrics.go
@@ -28,6 +28,10 @@ const (
 	MetricSampleTag = "metric-sample"
 )
 
+// DefaultReservoirSize and DefaultExpDecayAlpha are the values used for
+// histogram sampling when the "metric-sample" tag is not present. They create
+// an exponentially-decaying sample with the same behavior as UNIX load
+// averages.
 const (
 	DefaultReservoirSize = 1028
 	DefaultExpDecayAlpha = 0.015
@@ -80,7 +84,7 @@ var (
 // histogram. The tag value is a comma-separated list of the sample type and
 // the sample's parameters. The supported types are:
 //
-//   - "uniform": optionally acepts an integer for the reservoir size
+//   - "uniform": optionally accepts an integer for the reservoir size
 //   - "expdecay": optionally accepts an integer for the reservoir size and a
 //     float for the alpha value; you must set both or neither value
 //
@@ -120,7 +124,7 @@ var (
 //	}
 //
 // New panics if a functional metric is missing its compute function or if the
-// function has the wrong type. At this time, functional metrics to not support
+// function has the wrong type. At this time, functional metrics do not support
 // tagging.
 //
 // [rcrowley/go-metrics]: https://pkg.go.dev/github.com/rcrowley/go-metrics
@@ -241,7 +245,7 @@ func isMetric(typ reflect.Type) bool {
 	case counterType, gaugeType, gaugeFloat64Type, histogramType, meterType, timerType:
 		return true
 	case functionalGaugeType, functionalGaugeFloat64Type:
-		// Functional gagues cannot be tagged because there's currently no way
+		// Functional gauges cannot be tagged because there's currently no way
 		// to pass the tags in to the function. Without this, every tag will
 		// report the same value, making the tags redundant.
 		return !tagged

--- a/appmetrics/appmetrics_test.go
+++ b/appmetrics/appmetrics_test.go
@@ -1,0 +1,54 @@
+package appmetrics
+
+import (
+	"testing"
+
+	"github.com/rcrowley/go-metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+type SimpleMetrics struct {
+	FooCount      metrics.Counter `metric:"foo.count"`
+	BarCount      metrics.Counter `metric:"bar.count"`
+	ActiveWorkers metrics.Gauge   `metric:"active_workers"`
+}
+
+type FunctionalMetrics struct {
+	ActiveWorkers metrics.Gauge `metric:"active_workers" metric-func:"GetWorkers"`
+
+	workers int64
+}
+
+func (m *FunctionalMetrics) GetWorkers() int64 {
+	m.workers++
+	return m.workers
+}
+
+type SampleMetrics struct {
+	LatencyA metrics.Histogram `metric:"latency.a" metric-sample:"uniform,100"`
+	LatencyB metrics.Histogram `metric:"latency.b" metric-sample:"expdecay,20,0.1"`
+}
+
+func TestNew(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		m := New[SimpleMetrics]()
+		m.FooCount.Inc(1)
+		m.BarCount.Inc(1)
+		m.ActiveWorkers.Update(17)
+	})
+
+	t.Run("functional", func(t *testing.T) {
+		m := New[FunctionalMetrics]()
+		assert.Equal(t, int64(1), m.ActiveWorkers.Value())
+		assert.Equal(t, int64(2), m.ActiveWorkers.Value())
+	})
+
+	t.Run("sample", func(t *testing.T) {
+		m := New[SampleMetrics]()
+		m.LatencyA.Update(300)
+		m.LatencyB.Update(150)
+
+		assert.IsType(t, &metrics.UniformSample{}, m.LatencyA.Sample(), "incorrect sample type")
+		assert.IsType(t, &metrics.ExpDecaySample{}, m.LatencyB.Sample(), "incorrect sample type")
+	})
+}

--- a/appmetrics/appmetrics_test.go
+++ b/appmetrics/appmetrics_test.go
@@ -44,8 +44,8 @@ type SampleMetrics struct {
 }
 
 type TaggedMetrics struct {
-	Responses TaggedCounter `metric:"responses"`
-	QueueSize TaggedGauge   `metric:"queue_size"`
+	Responses Tagged[metrics.Counter] `metric:"responses"`
+	QueueSize Tagged[metrics.Gauge]   `metric:"queue_size"`
 }
 
 func TestNew(t *testing.T) {

--- a/appmetrics/appmetrics_test.go
+++ b/appmetrics/appmetrics_test.go
@@ -28,7 +28,7 @@ type SimpleMetrics struct {
 }
 
 type FunctionalMetrics struct {
-	ActiveWorkers *metrics.FunctionalGauge `metric:"active_workers"`
+	ActiveWorkers FunctionalGauge `metric:"active_workers"`
 
 	workers int64
 }

--- a/appmetrics/appmetrics_test.go
+++ b/appmetrics/appmetrics_test.go
@@ -28,7 +28,10 @@ type SimpleMetrics struct {
 }
 
 type FunctionalMetrics struct {
-	ActiveWorkers FunctionalGauge `metric:"active_workers"`
+	ActiveWorkers FunctionalGauge        `metric:"active_workers"`
+	Temperature   FunctionalGaugeFloat64 `metric:"temperature"`
+
+	ComputeTemperature func() float64
 
 	workers int64
 }
@@ -58,8 +61,13 @@ func TestNew(t *testing.T) {
 
 	t.Run("functional", func(t *testing.T) {
 		m := New[FunctionalMetrics]()
+		m.ComputeTemperature = func() float64 {
+			return 20
+		}
+
 		assert.Equal(t, int64(1), m.ActiveWorkers.Value())
 		assert.Equal(t, int64(2), m.ActiveWorkers.Value())
+		assert.Equal(t, float64(20), m.Temperature.Value())
 	})
 
 	t.Run("sample", func(t *testing.T) {

--- a/appmetrics/appmetrics_test.go
+++ b/appmetrics/appmetrics_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package appmetrics
 
 import (
@@ -29,6 +43,11 @@ type SampleMetrics struct {
 	LatencyB metrics.Histogram `metric:"latency.b" metric-sample:"expdecay,20,0.1"`
 }
 
+type TaggedMetrics struct {
+	Responses TaggedCounter `metric:"responses"`
+	QueueSize TaggedGauge   `metric:"queue_size"`
+}
+
 func TestNew(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		m := New[SimpleMetrics]()
@@ -50,5 +69,11 @@ func TestNew(t *testing.T) {
 
 		assert.IsType(t, &metrics.UniformSample{}, m.LatencyA.Sample(), "incorrect sample type")
 		assert.IsType(t, &metrics.ExpDecaySample{}, m.LatencyB.Sample(), "incorrect sample type")
+	})
+
+	t.Run("tagged", func(t *testing.T) {
+		m := New[TaggedMetrics]()
+		m.Responses.Tag("code:200").Inc(1)
+		m.QueueSize.Tag("reindex").Update(12)
 	})
 }

--- a/appmetrics/appmetrics_test.go
+++ b/appmetrics/appmetrics_test.go
@@ -14,12 +14,12 @@ type SimpleMetrics struct {
 }
 
 type FunctionalMetrics struct {
-	ActiveWorkers metrics.Gauge `metric:"active_workers" metric-func:"GetWorkers"`
+	ActiveWorkers *metrics.FunctionalGauge `metric:"active_workers"`
 
 	workers int64
 }
 
-func (m *FunctionalMetrics) GetWorkers() int64 {
+func (m *FunctionalMetrics) ComputeActiveWorkers() int64 {
 	m.workers++
 	return m.workers
 }

--- a/appmetrics/doc.go
+++ b/appmetrics/doc.go
@@ -1,0 +1,46 @@
+// Copyright 2023 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package appmetrics creates and registers metrics structs.
+//
+// Applications that report metrics often want to define those metrics in a
+// common type or package so they are easy to use in other parts of the
+// application. The appmetrics package provides a way to easily define,
+// initialize, and register these shared metric structs.
+//
+// A metrics struct contains one or more fields of a supported metric interface
+// type that have the "metric" tag giving the metric's name in a registry. The
+// metric types and the registry are defined by the [go-metrics] package.
+//
+// For global metrics, this struct is often exported as a field:
+//
+//	// in the app's "metrics" package
+//	type Metrics struct {
+//		Errors        metrics.Counter `metric:"errors"`
+//		ActiveWorkers metrics.Gauge   `metric:"active_workers"`
+//	}
+//
+//	var M *Metrics
+//
+//	func init() {
+//		M = appmetrics.New()
+//		appmetrics.Register(metrics.DefaultRegistry, M)
+//	}
+//
+//	// in a different package
+//	metrics.M.Errors.Inc(1)
+//	metrics.M.ActiveWorkers.Update(len(workers))
+//
+// [go-metrics]: https://pkg.go.dev/github.com/rcrowley/go-metrics
+package appmetrics

--- a/appmetrics/example_test.go
+++ b/appmetrics/example_test.go
@@ -1,0 +1,67 @@
+// Copyright 2023 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package appmetrics
+
+import (
+	"fmt"
+
+	"github.com/rcrowley/go-metrics"
+)
+
+type Metrics struct {
+	Counter       metrics.Counter         `metric:"counter"`
+	TaggedCounter Tagged[metrics.Counter] `metric:"counter.tagged"`
+
+	Gauge           metrics.Gauge   `metric:"gauge"`
+	FunctionalGauge FunctionalGauge `metric:"gauge.functional"`
+
+	calls int64
+}
+
+func (m *Metrics) ComputeFunctionalGauge() int64 {
+	m.calls++
+	return m.calls
+}
+
+func Example() {
+	// Initialize a Metrics struct
+	m := New[Metrics]()
+
+	// Register it with a registry
+	Register(metrics.DefaultRegistry, m)
+
+	// Report metrics
+	m.Counter.Inc(5)
+	m.TaggedCounter.Tag("foo").Inc(1)
+	m.TaggedCounter.Tag("bar").Inc(1)
+	m.Gauge.Update(42)
+
+	// Read metrics from the registry
+	metrics.Each(func(name string, m any) {
+		switch m := m.(type) {
+		case metrics.Counter:
+			fmt.Printf("%s: %d\n", name, m.Count())
+		case metrics.Gauge:
+			fmt.Printf("%s: %d\n", name, m.Value())
+		}
+	})
+
+	// Unordered output: counter: 5
+	// counter.tagged: 0
+	// counter.tagged[foo]: 1
+	// counter.tagged[bar]: 1
+	// gauge: 42
+	// gauge.functional: 1
+}

--- a/appmetrics/gauges.go
+++ b/appmetrics/gauges.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package appmetrics
 
 import (

--- a/appmetrics/gauges.go
+++ b/appmetrics/gauges.go
@@ -1,0 +1,57 @@
+package appmetrics
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/rcrowley/go-metrics"
+)
+
+const (
+	GaugeFunctionPrefix = "Compute"
+)
+
+// FunctionalGauge is a [metrics.Gauge] that computes its value by calling a
+// function.
+//
+// A FunctionalGauge cannot be used as a [Tagged] metric.
+type FunctionalGauge interface {
+	Snapshot() metrics.Gauge
+	Value() int64
+}
+
+// FunctionalGaugeFloat64 is a [metrics.GaugeFloat64] that computes its value
+// by calling a function.
+//
+// A FunctionalGaugeFloat64 cannot be used as a [Tagged] metric.
+type FunctionalGaugeFloat64 interface {
+	Snapshot() metrics.GaugeFloat64
+	Value() float64
+}
+
+func getGaugeFunction[N int64 | float64, F func() N](v reflect.Value, fieldName string) (F, error) {
+	name := GaugeFunctionPrefix + fieldName
+
+	m := v.Addr().MethodByName(name)
+	if !m.IsValid() {
+		// A method does not exist, look for a field with the name instead
+		m = v.FieldByName(name)
+		if !m.IsValid() {
+			return nil, fmt.Errorf("%s: method or field does not exist", name)
+		}
+		if m.Type().Kind() != reflect.Func {
+			return nil, fmt.Errorf("%s: field must be a function", name)
+		}
+	}
+
+	if m.Type().NumIn() != 0 {
+		return nil, fmt.Errorf("%s: function must take no parameters", name)
+	}
+	if m.Type().NumOut() != 1 {
+		return nil, fmt.Errorf("%s: function must return a single value", name)
+	}
+	if m.Type().Out(0) != reflect.TypeOf(N(0)) {
+		return nil, fmt.Errorf("%s: function must return a value of type %T", name, N(0))
+	}
+	return m.Interface().(F), nil
+}

--- a/appmetrics/tags.go
+++ b/appmetrics/tags.go
@@ -16,6 +16,7 @@ package appmetrics
 
 import (
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/rcrowley/go-metrics"
@@ -71,20 +72,14 @@ func (m *taggedMetric[M]) Tag(tags ...string) M {
 	var name strings.Builder
 	name.WriteString(m.name)
 
-	var n int
-	for _, t := range tags {
-		t = strings.TrimSpace(t)
-		if t != "" {
-			if n == 0 {
-				name.WriteString("[")
-			} else {
+	if tags := cleanAndSortTags(tags); len(tags) > 0 {
+		name.WriteString("[")
+		for i, t := range tags {
+			if i > 0 {
 				name.WriteString(",")
 			}
 			name.WriteString(t)
-			n++
 		}
-	}
-	if n > 0 {
 		name.WriteString("]")
 	}
 
@@ -119,4 +114,16 @@ func isTagged(typ reflect.Type) (bool, reflect.Type) {
 		return false, nil
 	}
 	return true, mt.Out(0)
+}
+
+func cleanAndSortTags(tags []string) []string {
+	cleanTags := make([]string, 0, len(tags))
+	for _, t := range tags {
+		t = strings.TrimSpace(t)
+		if t != "" {
+			cleanTags = append(cleanTags, t)
+		}
+	}
+	sort.Strings(cleanTags)
+	return cleanTags
 }

--- a/appmetrics/tags.go
+++ b/appmetrics/tags.go
@@ -26,11 +26,33 @@ var (
 )
 
 // Tagged is a metric with dynamic tags. The type M must be one of the
-// supported metric types exported by rcrowley/go-metrics.
+// supported metric types.
 //
 // The Tag method returns an instance of the metric that reports with the given
 // tags. Tags may be either plain values or key and values separated by a
 // colon.
+//
+// While Tagged metrics can be used directly, it's helpful to wrap them in a
+// function that accepts the expected tag values using the correct types. For
+// example:
+//
+//	struct M {
+//		Responses Tagged[metrics.Counter] `metric:"responses"`
+//	}
+//
+//	func (m *M) ResponsesByTypeAndStatus(typ string, status int) metrics.Counter {
+//		return m.Responses.Tag("type:" + type, "status:" + strconv.Itoa(stats))
+//	}
+//
+// Tags are added as a suffix to the base metric name: the tags are joined by
+// commas, then surrounded by square brackets. Using the previous example, the
+// full metric names might be:
+//
+//   - "responses[type:api,status:200]"
+//   - "responses[type:file,status:404]"
+//
+// Note that each unique combination of tags produces a separate metric in the
+// registry. For this reason avoid tags that can take many values, like IDs.
 type Tagged[M any] interface {
 	Tag(tags ...string) M
 }

--- a/appmetrics/tags.go
+++ b/appmetrics/tags.go
@@ -1,0 +1,93 @@
+// Copyright 2023 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package appmetrics
+
+import (
+	"strings"
+
+	"github.com/rcrowley/go-metrics"
+)
+
+// TaggedCounter is a metrics.Counter with dynamic tags.
+//
+// Tag returns an instance of a counter that reports with the given tags. Tags
+// may be either plain values or keys and values separated by a colon.
+type TaggedCounter interface {
+	Tag(tags ...string) metrics.Counter
+}
+
+// TaggedGauge is a metrics.Gauge with dynamic tags.
+//
+// Tag returns an instance of a gauge that reports with the given tags. Tags
+// may be either plain values or keys and values separated by a colon.
+type TaggedGauge interface {
+	Tag(tags ...string) metrics.Gauge
+}
+
+// TaggedGaugeFloat64 is a metrics.GaugeFloat64 with dynamic tags.
+//
+// Tag returns an instance of a gauge that reports with the given tags. Tags
+// may be either plain values or keys and values separated by a colon.
+type TaggedGaugeFloat64 interface {
+	Tag(tags ...string) metrics.GaugeFloat64
+}
+
+// TaggedHistogram is a metrics.Histogram with dynamic tags.
+//
+// Tag returns an instance of a histogram that reports with the given tags.
+// Tags may be either plain values or keys and values separated by a colon.
+type TaggedHistogram interface {
+	Tag(tags ...string) metrics.Histogram
+}
+
+// TaggedMeter is a metrics.Meter with dynamic tags.
+//
+// Tag returns an instance of a meter that reports with the given tags. Tags
+// may be either plain values or keys and values separated by a colon.
+type TaggedMeter interface {
+	Tag(tags ...string) metrics.Meter
+}
+
+// TaggedTimer is a metrics.Timer with dynamic tags.
+//
+// Tag returns an instance of a timer that reports with the given tags. Tags
+// may be either plain values or keys and values separated by a colon.
+type TaggedTimer interface {
+	Tag(tags ...string) metrics.Timer
+}
+
+type taggedMetric[M any] struct {
+	r         metrics.Registry
+	name      string
+	newMetric func() M
+}
+
+func (m *taggedMetric[M]) Tag(tags ...string) M {
+	name := m.name
+	if len(tags) > 0 {
+		name += "[" + strings.Join(tags, ",") + "]"
+	}
+	if m.r == nil {
+		return m.newMetric()
+	}
+	return m.r.GetOrRegister(name, m.newMetric).(M)
+}
+
+func (m *taggedMetric[M]) register(r metrics.Registry) {
+	m.r = r
+
+	// Add the bare metric immediately so emitters can find it in the registry
+	r.GetOrRegister(m.name, m.newMetric)
+}


### PR DESCRIPTION
This package contains utilities that make it easier to construct and  register metrics structs because you only have to specify the metric name and type in one place. It should hopefully help standardize how we configure metrics in various applications.

There's a bit of magic involved, so it's probably best to read the included docs and look at the examples to understand how this works. I'll also put together an example in a real internal application.

There were a few iterations on tagged and functional metrics, which you can see in the commit history, but I'm relatively happy with the final version shown here.
