### PR TITLE
Allow customizing timer units in Datadog export

### DIFF
--- a/baseapp/datadog/datadog.go
+++ b/baseapp/datadog/datadog.go
@@ -49,10 +49,15 @@ const (
 )
 
 var (
-	// TimerUnits sets the units used when exporting metrics.Timer metrics. By
-	// default, use the native unit of nanoseconds.
-	TimerUnits = time.Nanosecond
+	timerUnit = time.Nanosecond
 )
+
+// SetTimerUnit sets the units used when exporting metrics.Timer metrics. By
+// default, times are reported in nanoseconds. You must call this function
+// before starting any Emitter instances.
+func SetTimerUnit(unit time.Duration) {
+	timerUnit = unit
+}
 
 type Config struct {
 	Address  string        `yaml:"address" json:"address"`
@@ -181,5 +186,5 @@ func tagsFromName(name string) (string, []string) {
 }
 
 func convertTime[N int64 | float64](n N) float64 {
-	return float64(n) / float64(TimerUnits)
+	return float64(n) / float64(timerUnit)
 }

--- a/baseapp/datadog/datadog.go
+++ b/baseapp/datadog/datadog.go
@@ -157,7 +157,7 @@ func (e *Emitter) EmitOnce() {
 		case metrics.Timer:
 			ms := m.Snapshot()
 			_ = e.client.Gauge(name+".avg", convertTime(ms.Mean()), tags, 1)
-			_ = e.client.Gauge(name+".count", convertTime(ms.Count()), tags, 1)
+			_ = e.client.Gauge(name+".count", float64(ms.Count()), tags, 1)
 			_ = e.client.Gauge(name+".max", convertTime(ms.Max()), tags, 1)
 			_ = e.client.Gauge(name+".median", convertTime(ms.Percentile(0.5)), tags, 1)
 			_ = e.client.Gauge(name+".min", convertTime(ms.Min()), tags, 1)


### PR DESCRIPTION
The `metrics.Timer` type natively reports in nanoseconds, which is usually too small to be useful. Applications can now set the `TimerUnits` global variable to a different unit to scale values before they are sent to Datadog. We set the default value to nanoseconds for compatibility.

This may change how we report request latency in #181.