### PR TITLE
Add feature to ignore requests in logs/metrics

### DIFF
--- a/baseapp/example_ignore_test.go
+++ b/baseapp/example_ignore_test.go
@@ -1,0 +1,56 @@
+// Copyright 2023 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package baseapp
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+)
+
+func Example_ignoreRequests() {
+	ignoreHandler := NewIgnoreHandler()
+
+	printHandler := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+
+			fmt.Printf("%s - logs: %t\n", r.URL.Path, IsIgnored(r, IgnoreRule{Logs: true}))
+			fmt.Printf("%s - metrics: %t\n", r.URL.Path, IsIgnored(r, IgnoreRule{Metrics: true}))
+		})
+	}
+
+	exampleHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/health" {
+			Ignore(r, IgnoreRule{Logs: true})
+		}
+	})
+
+	h := ignoreHandler(printHandler(exampleHandler))
+
+	r1 := httptest.NewRequest("GET", "/api/health", nil)
+	w1 := httptest.NewRecorder()
+	h.ServeHTTP(w1, r1)
+
+	r2 := httptest.NewRequest("GET", "/api/auth/login", nil)
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, r2)
+
+	// Output:
+	// /api/health - logs: true
+	// /api/health - metrics: false
+	// /api/auth/login - logs: false
+	// /api/auth/login - metrics: false
+}

--- a/baseapp/ignore.go
+++ b/baseapp/ignore.go
@@ -1,0 +1,92 @@
+// Copyright 2023 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package baseapp
+
+import (
+	"context"
+	"net/http"
+)
+
+type ignoreCtxKey struct{}
+
+var (
+	zeroRule IgnoreRule
+)
+
+// NewIgnoreHandler returns middleware that tracks whether specific requests
+// should be ignored in logs and metrics.
+func NewIgnoreHandler() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var rule IgnoreRule
+			r = r.WithContext(context.WithValue(r.Context(), ignoreCtxKey{}, &rule))
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// IgnoreRule specifies which types of reporting to ignore for a particular
+// request.
+type IgnoreRule struct {
+	// If true, do not log this request
+	Logs bool
+
+	// If true, do not report metrics for this request
+	Metrics bool
+}
+
+// Ignore sets reporting to ignore for a request. Use this to disable logging
+// or metrics for particular request types, like health checks. Call Ignore
+// with an empty rule to re-enable reporting for a request that was previously
+// ignored.
+//
+// Ignore only works if the middleware returned by NewIgnoreHandler is used
+// before the handler and before any reporting middleware in the middleware
+// stack. If this middleware does not exist, Ignore has no effect.
+func Ignore(r *http.Request, rule IgnoreRule) {
+	ctxRule, ok := r.Context().Value(ignoreCtxKey{}).(*IgnoreRule)
+	if ok {
+		*ctxRule = rule
+	}
+}
+
+// IgnoreAll is equivalent to calling Ignore with an IgnoreRule that ignores
+// all possible reporting.
+func IgnoreAll(r *http.Request) {
+	Ignore(r, IgnoreRule{
+		Logs:    true,
+		Metrics: true,
+	})
+}
+
+// IsIgnored returns true if the request ignores all of the reporting types set
+// in rule. The request may also ignore other reporting types not set in rule.
+func IsIgnored(r *http.Request, rule IgnoreRule) bool {
+	if rule == zeroRule {
+		return false
+	}
+
+	ctxRule, ok := r.Context().Value(ignoreCtxKey{}).(*IgnoreRule)
+	if ok {
+		if rule.Logs && !ctxRule.Logs {
+			return false
+		}
+		if rule.Metrics && !ctxRule.Metrics {
+			return false
+		}
+		return true
+	}
+	return false
+}

--- a/baseapp/metrics.go
+++ b/baseapp/metrics.go
@@ -83,6 +83,10 @@ func RegisterDefaultMetrics(registry metrics.Registry) {
 
 // CountRequest is an AccessCallback that records metrics about the request.
 func CountRequest(r *http.Request, status int, _ int64, elapsed time.Duration) {
+	if IsIgnored(r, IgnoreRule{Metrics: true}) {
+		return
+	}
+
 	registry := MetricsCtx(r.Context())
 
 	if c := registry.Get(MetricsKeyRequests); c != nil {


### PR DESCRIPTION
We've had several requests to not log health check requests in apps built on baseapp (e.g. https://github.com/palantir/policy-bot/issues/172) and in general, these logs do clutter the log output and make finding "real" requests more difficult. This is less of a problem with metrics, but health check requests are still likely to inflate request counts and alter latency distributions.

Instead of having some kind of complicated pattern-matching rule for paths, allow handlers to ignore requests on a per-request basis. For example, this means health check handlers could ignore all requests or only ignore successful requests.