### PR TITLE
Add doAuthWithRelayState() handler

### DIFF
--- a/baseapp/auth/saml/README.md
+++ b/baseapp/auth/saml/README.md
@@ -44,3 +44,10 @@ s.Mux().HandleFunc(pat.Get("/auth"), sp.DoAuth)
 
 _ = s.Start()
 ```
+
+As an alternative, you can pass in relayState by using the `DoAuthWithRelayState()` function as shown below:
+```golang
+s.Mux().Handle(pat.Get("/auth/state"), sp.DoAuthWithRelayState("yourstate"))
+```
+Please note that this package does not perform validation on the relayState. If the RelayState parameter is expected 
+to be a URL, ensure that the URL is properly validated and explicitly included on an allowlist to prevent open redirect attacks.

--- a/baseapp/auth/saml/serviceprovider.go
+++ b/baseapp/auth/saml/serviceprovider.go
@@ -150,6 +150,18 @@ func (s *ServiceProvider) getSAMLSettingsForRequest(r *http.Request) *saml.Servi
 // DoAuth takes an http.ResponseWriter that has not been written to yet, and conducts and SP initiated login
 // If the flow proceeds correctly the user should be redirected to the handler provided by ACSHandler().
 func (s *ServiceProvider) DoAuth(w http.ResponseWriter, r *http.Request) {
+	s.handleAuth(w, r, "")
+}
+
+// DoAuthWithRelayState similar to DoAuth, but allow to pass in relayState, and allow ACSHandler() to retrieve it back
+// from the SAML response.
+func (s *ServiceProvider) DoAuthWithRelayState(relayState string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.handleAuth(w, r, relayState)
+	})
+}
+
+func (s *ServiceProvider) handleAuth(w http.ResponseWriter, r *http.Request, relayState string) {
 	sp := s.getSAMLSettingsForRequest(r)
 
 	request, err := sp.MakeAuthenticationRequest(sp.GetSSOBindingLocation(saml.HTTPRedirectBinding), saml.HTTPRedirectBinding, saml.HTTPPostBinding)
@@ -163,7 +175,7 @@ func (s *ServiceProvider) DoAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	target, err := request.Redirect("", sp)
+	target, err := request.Redirect(relayState, sp)
 	if err != nil {
 		s.onError(w, r, newError(errors.Wrap(err, "failed to generate redirect URL"), http.StatusInternalServerError))
 		return


### PR DESCRIPTION
## Description
The current `doAuth()` handler lacks the capability to accept a `relayState` parameter, even though the upstream SAML package has provisions for it. To address this limitation while ensuring backward compatibility, this PR introduces a new handler, `doAuthWithRelayState()`. This new handler will allow developers to pass in a relayState, providing greater flexibility and alignment with the upstream package's capabilities.

## Key Changes
- New Handler: `doAuthWithRelayState()` is added to support the relayState parameter.
- Backward Compatibility: The existing `doAuth()` handler remains unchanged, ensuring that current implementations continue to function without modification.
- Documentation: Updated the documentation to include usage examples for doAuthWithRelayState() and explain how to use the handler.

## Motivation
By supporting relayState, we align with the upstream SAML package's capabilities, providing developers with more options for managing authentication flows. This enhancement is particularly useful in scenarios where maintaining state across authentication requests is necessary.


