### PR TITLE
Disable label releases in Autorelease

### DIFF
--- a/.palantir/autorelease.yml
+++ b/.palantir/autorelease.yml
@@ -1,3 +1,4 @@
 version: 3
 options:
+  disable_label_releases: true
   allow_patch_releases_on_major_series_branches: true


### PR DESCRIPTION
Humans should review the pending changes in the Autorelease UI before creating new releases.