### PR TITLE
Add dependabot labels, disable Go updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,6 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: gomod
-    directory: /
+    labels: ["no changelog", "merge when ready", "dependencies", "github_actions"]
     schedule:
       interval: weekly


### PR DESCRIPTION
Also, remove the golang updater since excavator gets to these
