### PR TITLE
Do not register bare Tagged metrics

### DIFF
--- a/appmetrics/example_test.go
+++ b/appmetrics/example_test.go
@@ -59,7 +59,6 @@ func Example() {
 	})
 
 	// Unordered output: counter: 5
-	// counter.tagged: 0
 	// counter.tagged[foo]: 1
 	// counter.tagged[bar]: 1
 	// gauge: 42

--- a/appmetrics/tags.go
+++ b/appmetrics/tags.go
@@ -51,6 +51,10 @@ var (
 //
 // Note that each unique combination of tags produces a separate metric in the
 // registry. For this reason avoid tags that can take many values, like IDs.
+//
+// Tagged metrics are lazy and do not appear in the registry until the first
+// call to [Tag]. Applications that use a known set of tags may wish to
+// pre-register metrics by calling [Tag] during application startup.
 type Tagged[M any] interface {
 	// Tag returns an instance of the metric that reports with the given tags.
 	// Tags may be either plain values or key-value pairs separated by a colon.
@@ -88,9 +92,6 @@ func (m *taggedMetric[M]) Tag(tags ...string) M {
 
 func (m *taggedMetric[M]) register(r metrics.Registry) {
 	m.r = r
-
-	// Add the bare metric immediately so emitters can find it in the registry
-	r.GetOrRegister(m.name, m.newMetric)
 }
 
 // isTagged determines if typ is a Tagged instantiation and returns the


### PR DESCRIPTION
When I wrote this package, I had Tagged metrics register their "bare" variant so that the metric showed up in emitters immediately. This turns out to have two problems:

1. When using global labels, it can create conflicts that break the Prometheus exporter. Consider the metric 'count' that has the 'job' tag. The application explicitly sets a 'job' value when incrementing the metric. The emitter configuration also sets a value for the 'job' label that applies to all metrics. Assume the value for the 'job' label is 'foo'. Initially, the registry contains a single, bare metric:

       count: 0

   This is emitted as `count{job=foo}: 0`. Then, the application increments the count metric for the 'foo' job. The registry now contains two metrics:

       count: 0
       count[job=foo]: 1

   This produces two lines in the emitter:

       count{job=foo}: 0
       count{job=foo}: 1

   Prometheus detects this duplicate key with different values and returns a 500 error, breaking all metric emission.

2. When aggregating or splitting timeseries by tags, you end up with a series with no tags that always has the value 0, cluttering dashboard or requiring an explicit filter to exclude.

Solve both of these problems by removing the bare metric registration and only registering metrics when we know the tag values. Since you could not access the bare value directly (except by introspecting the registry), this shouldn't break applications. But it may cause odd behavior in dashboards or monitors that expected to find values for the untagged series.

Applications that work with a fixed set of tags and want to pre-register metrics can do so by calling the `Tag()` function during startup.
