### PR TITLE
Group codeql package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     labels: ["no changelog", "merge when ready", "dependencies", "github_actions"]
     schedule:
       interval: weekly
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
These apparently need to bump together. Currently #485 , #484 and #483 are failing with independent upgrades.