### PR TITLE
Added RealIP middleware and flag to overwrite RemoteAddr

### DIFF
--- a/baseapp/middleware.go
+++ b/baseapp/middleware.go
@@ -15,13 +15,20 @@
 package baseapp
 
 import (
+	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/bluekeyes/hatpear"
 	"github.com/rcrowley/go-metrics"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/hlog"
+)
+
+const (
+	XForwardedFor = "X-Forwarded-For"
+	XRealIP       = "X-Real-Ip"
 )
 
 // DefaultMiddleware returns the default middleware stack. The stack:
@@ -56,6 +63,35 @@ func NewMetricsHandler(registry metrics.Registry) func(http.Handler) http.Handle
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// RealIP overwrites the request RemoteAddr with the client IP from the
+// X-Forwarded-For or X-Real-Ip header. Downstream request logging then reports
+// the client, not the reverse proxy. RealIP trusts these headers, so use it only
+// when a trusted proxy such as Traefik sits in front of the server. It must run
+// before any middleware that reads RemoteAddr, so place it first in the stack.
+func RealIP(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ip := realIPFromRequest(r); ip != "" {
+			r.RemoteAddr = ip
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func realIPFromRequest(r *http.Request) string {
+	if forwarded := r.Header.Get(XForwardedFor); forwarded != "" {
+		first, _, _ := strings.Cut(forwarded, ",")
+		return strings.TrimSpace(first)
+	}
+	if ip := r.Header.Get(XRealIP); ip != "" {
+		return strings.TrimSpace(ip)
+	}
+
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
 }
 
 // LogRequest is an AccessCallback that logs request information.

--- a/baseapp/params.go
+++ b/baseapp/params.go
@@ -67,6 +67,14 @@ func WithMiddleware(middleware ...func(http.Handler) http.Handler) Param {
 	}
 }
 
+// WithRealIP set a flag so that the server's middleware stack is prepended with RealIP
+func WithRealIP() Param {
+	return func(b *Server) error {
+		b.realIP = true
+		return nil
+	}
+}
+
 // WithUTCNanoTime adds a UTC timestamp with nanosecond precision to log lines.
 func WithUTCNanoTime() Param {
 	return func(b *Server) error {

--- a/baseapp/server.go
+++ b/baseapp/server.go
@@ -40,6 +40,7 @@ type Server struct {
 	logger     zerolog.Logger
 	mux        *goji.Mux
 	server     *http.Server
+	realIP     bool
 
 	registry metrics.Registry
 
@@ -70,6 +71,10 @@ func NewServer(c HTTPConfig, params ...Param) (*Server, error) {
 
 	if base.middleware == nil {
 		base.middleware = DefaultMiddleware(base.logger, base.registry)
+	}
+
+	if base.realIP {
+		base.middleware = append([]func(http.Handler) http.Handler{RealIP}, base.middleware...)
 	}
 
 	for _, middleware := range base.middleware {


### PR DESCRIPTION
## Before this PR
When a server created with `go-baseapp` ran behind a proxy, it may overwrite the original client's IP address with that of the proxy. The server would then have no way of knowing the original client's IP. The `client_ip` that's logged as part of the `DefaultParams`' middleware stack would always point to the proxy's IP address in this scenario

## After this PR
The `Param` `WithRealIP` was added. It sets a flag that will prepend the `RealIP` middleware to the rest of the server's middleware stack.
`RealIP` replaces the request's `RemoteAddr` with the first IP address in the `X-Forwarded-For` header or, if the header does not exist, the address in the `X-Real-IP` header. If neither exist, it falls back to `RemoteAddr`
==COMMIT_MSG==
Added `Param` and middleware to replace a request's `RemoteAddr` with an IP from `X-Forwarded-For` or `X-Real-IP` depending on if the headers exist
==COMMIT_MSG==

## Possible downsides?
If the `WithRealIP` `Param` is specified, `RemoteAddr` no longer contains a request's port number. That's due to the fact that ports aren't included in the `X-Forwarded-For` or `X-Real-IP` headers.
Since this `Param` is optional though, this isn't a problem. Just something to keep in mind


This has been verified with a local instance of `excavator`